### PR TITLE
feat: Add configurable parameters for binance-proxy in Helm chart

### DIFF
--- a/charts/binance-proxy/Chart.yaml
+++ b/charts/binance-proxy/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 1.2.4
 description: Binance websocket proxy
 name: binance-proxy
-version: 0.0.6
+version: 0.0.7
 type: application
 keywords:
   - websocket

--- a/charts/binance-proxy/templates/deployment.yaml
+++ b/charts/binance-proxy/templates/deployment.yaml
@@ -33,12 +33,30 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- if .Values.binanceProxy.verbose }}
+            - "-v"
+            {{- end }}
+            - "-p={{ .Values.binanceProxy.portSpot }}"
+            - "-t={{ .Values.binanceProxy.portFutures }}"
+            {{- if .Values.binanceProxy.disableFakeCandles }}
+            - "-c"
+            {{- end }}
+            {{- if .Values.binanceProxy.disableSpot }}
+            - "-s"
+            {{- end }}
+            {{- if .Values.binanceProxy.disableFutures }}
+            - "-f"
+            {{- end }}
+            {{- if .Values.binanceProxy.alwaysShowForwards }}
+            - "-a"
+            {{- end }}
           ports:
             - name: port-spot
-              containerPort: 8090
+              containerPort: {{ .Values.binanceProxy.portSpot }}
               protocol: TCP
             - name: port-futures
-              containerPort: 8091
+              containerPort: {{ .Values.binanceProxy.portFutures }}
               protocol: TCP
           env:
             - name: TZ

--- a/charts/binance-proxy/templates/service.yaml
+++ b/charts/binance-proxy/templates/service.yaml
@@ -15,7 +15,13 @@ spec:
   {{- end }}
 {{- with .Values.service.ports }}
   ports:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    - port: {{ .Values.binanceProxy.portSpot }}
+      targetPort: {{ .Values.binanceProxy.portSpot }}
+      protocol: TCP
+      name: port-spot
+    - port: {{ .Values.binanceProxy.portFutures }}
+      targetPort: {{ .Values.binanceProxy.portFutures }}
+      protocol: TCP
+      name: port-futures
   selector:
     {{- include "app.selectorLabels" . | nindent 4 }}

--- a/charts/binance-proxy/values.yaml
+++ b/charts/binance-proxy/values.yaml
@@ -1,5 +1,5 @@
 ---
-replicaCount: 1
+replicaCount: {}
 
 image:
   repository: nightshift2k/binance-proxy
@@ -9,7 +9,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-timezone: UTC
+timezone: CET
 
 serviceAccount:
   create: true
@@ -23,13 +23,8 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  capabilities:
+    add: ["NET_ADMIN"]
 
 service:
   type: ClusterIP

--- a/charts/binance-proxy/values.yaml
+++ b/charts/binance-proxy/values.yaml
@@ -32,14 +32,14 @@ service:
   loadBalancerIP: ""
 
   ports:
-    - port: 8090
+    - name: port-spot
+      protocol: TCP
       targetPort: 8090
+      port: 8090
+    - name: port-futures
       protocol: TCP
-      name: port-spot
-    - port: 8091
       targetPort: 8091
-      protocol: TCP
-      name: port-futures
+      port: 8091
 
 resources: {}
 # limits:
@@ -59,3 +59,12 @@ autoscaling:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+binanceProxy:
+  verbose: false            # -v, --verbose
+  portSpot: 8090            # -p, --port-spot
+  portFutures: 8091         # -t, --port-futures
+  disableFakeCandles: false # -c, --disable-fake-candles
+  disableSpot: false        # -s, --disable-spot
+  disableFutures: false     # -f, --disable-futures
+  alwaysShowForwards: false # -a, --always-show-forwards


### PR DESCRIPTION
- **Description**: 
  This commit adds support for manually configuring the `binance-proxy` application parameters through the `values.yaml` file in the Helm chart. This enhancement allows users to customize settings such as verbosity, port bindings, and feature toggles directly, without needing to edit the chart templates.

- Added a new `binanceProxy` section in `values.yaml` to specify parameters like `verbose`, `portSpot`, `portFutures`, `disableFakeCandles`, and more.
- Updated `deployment.yaml` to dynamically pass these parameters as command-line arguments to the container, based on the values defined in `values.yaml`.
- Modified `service.yaml` to align the service ports with the configured values from `values.yaml`.
- Designed the Helm chart to remain flexible and user-configurable, enabling tailored behavior for `binance-proxy`.